### PR TITLE
Fixed: Navigation Drawer Header Image & Username are Clicakble 

### DIFF
--- a/sphinx/screens/dashboard/dashboard/src/main/java/chat/sphinx/dashboard/ui/DashboardFragment.kt
+++ b/sphinx/screens/dashboard/dashboard/src/main/java/chat/sphinx/dashboard/ui/DashboardFragment.kt
@@ -315,6 +315,9 @@ internal class DashboardFragment : MotionLayoutFragment<
             navDrawer.navDrawerButtonProfile.setOnClickListener {
                 lifecycleScope.launch { viewModel.navDrawerNavigator.toProfileScreen() }
             }
+            navDrawer.navDrawerButtonHeaderProfile.setOnClickListener {
+                lifecycleScope.launch { viewModel.navDrawerNavigator.toProfileScreen() }
+            }
             navDrawer.layoutButtonAddFriend.layoutConstraintButtonAddFriend.setOnClickListener {
                 lifecycleScope.launch { viewModel.navDrawerNavigator.toAddFriendDetail() }
             }

--- a/sphinx/screens/dashboard/dashboard/src/main/res/layout/layout_dashboard_nav_drawer.xml
+++ b/sphinx/screens/dashboard/dashboard/src/main/res/layout/layout_dashboard_nav_drawer.xml
@@ -17,6 +17,12 @@
         android:layout_marginStart="@dimen/default_layout_margin"
         app:layout_constraintTop_toTopOf="parent">
 
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/nav_drawer_button_header_profile"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toTopOf="parent">
+
         <androidx.cardview.widget.CardView
             android:id="@+id/card_view_profile_image"
             android:layout_width="@dimen/nav_drawer_header_profile_picture_xy"
@@ -54,6 +60,8 @@
             app:layout_constraintTop_toTopOf="parent"
             tools:text="Matthew long name to see 2 line text wrap"/>
 
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
         <androidx.appcompat.widget.AppCompatTextView
             android:id="@+id/nav_drawer_text_view_sats_balance"
             android:layout_width="0dp"
@@ -65,8 +73,8 @@
             android:textSize="14sp"
             android:fontFamily="@font/montserrat_regular"
             android:layout_marginTop="15dp"
-            app:layout_constraintStart_toStartOf="@+id/nav_drawer_text_view_profile_name"
-            app:layout_constraintTop_toBottomOf="@+id/nav_drawer_text_view_profile_name"
+            app:layout_constraintStart_toStartOf="@+id/nav_drawer_button_header_profile"
+            app:layout_constraintTop_toBottomOf="@+id/nav_drawer_button_header_profile"
             tools:text="100,000,000" />
 
         <androidx.appcompat.widget.AppCompatTextView


### PR DESCRIPTION
when you click on navigation drawer header which are image and username navigate to profile screen 